### PR TITLE
Properly escape search queries in URLs

### DIFF
--- a/python_picnic_api2/client.py
+++ b/python_picnic_api2/client.py
@@ -1,5 +1,6 @@
 import re
 from hashlib import md5
+from urllib.parse import quote
 
 import typing_extensions
 
@@ -95,7 +96,7 @@ class PicnicAPI:
         return self._get("/user")
 
     def search(self, term: str):
-        path = f"/pages/search-page-results?search_term={term}"
+        path = f"/pages/search-page-results?search_term={quote(term)}"
         raw_results = self._get(path, add_picnic_headers=True)
         return _extract_search_results(raw_results)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -98,6 +98,14 @@ class TestClient(unittest.TestCase):
             headers=PICNIC_HEADERS,
         )
 
+    def test_search_encoding(self):
+        self.client.search("Gut&Günstig H-Milch")
+        self.session_mock().get.assert_called_with(
+            self.expected_base_url
+            + "/pages/search-page-results?search_term=Gut%26G%C3%BCnstig%20H-Milch",
+            headers=PICNIC_HEADERS,
+        )
+
     def test_get_cart(self):
         self.client.get_cart()
         self.session_mock().get.assert_called_with(


### PR DESCRIPTION
This PR adds URL encoding to the search function. Lacking of which may have caused invalid "No Product found"-situations. Although this code is mostly unchanged since the initial release of the library, it's better to be safe. 

Test with a real product has been introduced to check the resulting URL.