### PR TITLE
Extract category from article

### DIFF
--- a/integration_tests/test_client.py
+++ b/integration_tests/test_client.py
@@ -53,7 +53,7 @@ def test_get_article():
 
 def test_get_article_with_category_name():
     with pytest.raises(NotImplementedError):
-        picnic.get_article("s1018620", add_category_name=True)
+        picnic.get_article("s1018620", add_category=True)
 
 
 def test_get_article_by_gtin():
@@ -81,7 +81,8 @@ def test_add_product():
 
     assert isinstance(response, dict)
     assert "items" in response
-    assert any(item["id"] == "s1018620" for item in response["items"][0]["items"])
+    assert any(
+        item["id"] == "s1018620" for item in response["items"][0]["items"])
     assert _get_amount(response, "s1018620") == 2
 
 

--- a/integration_tests/test_client.py
+++ b/integration_tests/test_client.py
@@ -52,8 +52,10 @@ def test_get_article():
 
 
 def test_get_article_with_category_name():
-    with pytest.raises(NotImplementedError):
-        picnic.get_article("s1018620", add_category=True)
+    response = picnic.get_article("s1018620", add_category=True)
+    assert isinstance(response, dict)
+    assert "category" in response
+    assert response["category"]["name"] == "H-Milch"
 
 
 def test_get_article_by_gtin():

--- a/src/python_picnic_api2/client.py
+++ b/src/python_picnic_api2/client.py
@@ -114,8 +114,10 @@ class PicnicAPI:
             return None
 
         color_regex = re.compile(r"#\(#\d{6}\)")
-        producer = re.sub(color_regex, "", str(article_details[1].get("markdown", "")))
-        article_name = re.sub(color_regex, "", str(article_details[0]["markdown"]))
+        producer = re.sub(color_regex, "", str(
+            article_details[1].get("markdown", "")))
+        article_name = re.sub(color_regex, "", str(
+            article_details[0]["markdown"]))
 
         article = {"name": f"{producer} {article_name}", "id": article_id}
 

--- a/src/python_picnic_api2/client.py
+++ b/src/python_picnic_api2/client.py
@@ -101,7 +101,7 @@ class PicnicAPI:
     def get_cart(self):
         return self._get("/cart")
 
-    def get_article(self, article_id: str, add_category_name=False):
+    def get_article(self, article_id: str, add_category=False):
         path = f"/pages/product-details-page-root?id={article_id}" + \
             "&show_category_action=true"
         data = self._get(path, add_picnic_headers=True)
@@ -114,7 +114,7 @@ class PicnicAPI:
             return None
 
         article = {}
-        if add_category_name:
+        if add_category:
             cat_node = find_nodes_by_content(
                 data, {"id": "category-button"}, max_nodes=1)
             if len(cat_node) == 0:

--- a/src/python_picnic_api2/client.py
+++ b/src/python_picnic_api2/client.py
@@ -8,6 +8,7 @@ from .helper import (
     _extract_search_results,
     _tree_generator,
     _url_generator,
+    find_nodes_by_content,
 )
 from .session import PicnicAPISession, PicnicAuthError
 
@@ -171,6 +172,17 @@ class PicnicAPI:
 
     def get_categories(self, depth: int = 0):
         return self._get(f"/my_store?depth={depth}")["catalog"]
+
+    def get_category_by_ids(self, l2_id: int, l3_id: int):
+        path = "/pages/L2-category-page-root" + \
+            f"?category_id={l2_id}&l3_category_id={l3_id}"
+        data = self._get(path, add_picnic_headers=True)
+        nodes = find_nodes_by_content(
+            data, {"id": f"vertical-article-tiles-sub-header-{l3_id}"}, max_nodes=1)
+        if len(nodes) == 0:
+            raise KeyError("Could not find category with specified IDs")
+        return {"l2_id": l2_id, "l3_id": l3_id,
+                "name": nodes[0]["pml"]["component"]["accessibilityLabel"]}
 
     def print_categories(self, depth: int = 0):
         tree = "\n".join(_tree_generator(self.get_categories(depth=depth)))

--- a/src/python_picnic_api2/helper.py
+++ b/src/python_picnic_api2/helper.py
@@ -112,7 +112,7 @@ def find_nodes_by_content(node, filter, max_nodes: int = 10):
                 continue
             if isinstance(v, list):
                 for item in v:
-                    if isinstance(v, (dict, list)):
+                    if isinstance(v, dict | list):
                         nodes.extend(find_nodes_by_content(
                             item, filter, max_nodes))
                         continue

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -163,11 +163,13 @@ class TestClient(unittest.TestCase):
         )
 
         category_patch = patch(
-            "python_picnic_api2.client.PicnicAPI.get_category_by_ids").start()
-        category_patch.return_value = {
+            "python_picnic_api2.client.PicnicAPI.get_category_by_ids")
+        category_patch.start().return_value = {
             "l2_id": 2000, "l3_id": 3000, "name": "Test"}
 
         article = self.client.get_article("p3f2qa", True)
+
+        category_patch.stop()
         self.session_mock().get.assert_called_with(
             "https://storefront-prod.nl.picnicinternational.com/api/15/pages/product-details-page-root?id=p3f2qa&show_category_action=true",
             headers=PICNIC_HEADERS,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,7 +110,7 @@ class TestClient(unittest.TestCase):
     def test_get_article(self):
         self.client.get_article("p3f2qa")
         self.session_mock().get.assert_called_with(
-            "https://storefront-prod.nl.picnicinternational.com/api/15/pages/product-details-page-root?id=p3f2qa",
+            "https://storefront-prod.nl.picnicinternational.com/api/15/pages/product-details-page-root?id=p3f2qa&show_category_action=true",
             headers=PICNIC_HEADERS,
         )
 
@@ -219,6 +219,30 @@ class TestClient(unittest.TestCase):
             categories[0],
             {"type": "CATEGORY", "id": "purchases", "name": "Besteld"},
         )
+
+    def test_get_category_by_ids(self):
+        self.session_mock().get.return_value = self.MockResponse(
+            {"children": [
+                {
+                    "id": "vertical-article-tiles-sub-header-22193",
+                    "pml": {
+                        "component": {
+                            "accessibilityLabel": "Halvarine"
+                        }
+                    }
+                }
+            ]},
+            200
+        )
+
+        category = self.client.get_category_by_ids(1000, 22193)
+        self.session_mock().get.assert_called_with(
+            f"{self.expected_base_url}/pages/L2-category-page-root" +
+            "?category_id=1000&l3_category_id=22193", headers=PICNIC_HEADERS
+        )
+
+        self.assertDictEqual(
+            category, {"name": "Halvarine", "l2_id": 1000, "l3_id": 22193})
 
     def test_get_auth_exception(self):
         self.session_mock().get.return_value = self.MockResponse(


### PR DESCRIPTION
This PR adds the ability to extract the Level 3 category of an article by its id. This also re-enables the parameter `add_category_name` for the function `get_article`.

Fixes #15 