### PR TITLE
fix: supply client version for cart operations

### DIFF
--- a/src/python_picnic_api2/client.py
+++ b/src/python_picnic_api2/client.py
@@ -176,7 +176,7 @@ class PicnicAPI:
         return SearchResult.from_page(raw_results)
 
     def get_cart(self) -> Cart:
-        return Cart.from_api(self._get("/cart"))
+        return Cart.from_api(self._get("/cart", add_picnic_headers=True))
 
     def get_article(self, article_id: str, add_category=False) -> Article | None:
         path = f"/pages/product-details-page-root?id={article_id}" + \
@@ -212,14 +212,14 @@ class PicnicAPI:
 
     def add_product(self, product_id: str, count: int = 1) -> Cart:
         data = {"product_id": product_id, "count": count}
-        return Cart.from_api(self._post("/cart/add_product", data))
+        return Cart.from_api(self._post("/cart/add_product", data, add_picnic_headers=True))
 
     def remove_product(self, product_id: str, count: int = 1) -> Cart:
         data = {"product_id": product_id, "count": count}
-        return Cart.from_api(self._post("/cart/remove_product", data))
+        return Cart.from_api(self._post("/cart/remove_product", data, add_picnic_headers=True))
 
     def clear_cart(self) -> Cart:
-        return Cart.from_api(self._post("/cart/clear"))
+        return Cart.from_api(self._post("/cart/clear", add_picnic_headers=True))
 
     def get_delivery_slots(self) -> DeliverySlots:
         return DeliverySlots.from_api(self._get("/cart/delivery_slots"))

--- a/src/python_picnic_api2/client.py
+++ b/src/python_picnic_api2/client.py
@@ -212,11 +212,13 @@ class PicnicAPI:
 
     def add_product(self, product_id: str, count: int = 1) -> Cart:
         data = {"product_id": product_id, "count": count}
-        return Cart.from_api(self._post("/cart/add_product", data, add_picnic_headers=True))
+        return Cart.from_api(self._post("/cart/add_product", data,
+                                        add_picnic_headers=True))
 
     def remove_product(self, product_id: str, count: int = 1) -> Cart:
         data = {"product_id": product_id, "count": count}
-        return Cart.from_api(self._post("/cart/remove_product", data, add_picnic_headers=True))
+        return Cart.from_api(self._post("/cart/remove_product", data,
+                                        add_picnic_headers=True))
 
     def clear_cart(self) -> Cart:
         return Cart.from_api(self._post("/cart/clear", add_picnic_headers=True))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -254,7 +254,8 @@ class TestClient(unittest.TestCase):
         )
         cart = self.client.get_cart()
         self.session_mock().get.assert_called_with(
-            self.expected_base_url + "/cart", headers=None
+            self.expected_base_url + "/cart",
+            headers=PICNIC_HEADERS,
         )
         self.assertEqual(cart.type, "ORDER")
         self.assertEqual(cart.total_count, 3)
@@ -267,6 +268,7 @@ class TestClient(unittest.TestCase):
         self.session_mock().post.assert_called_with(
             self.expected_base_url + "/cart/add_product",
             json={"product_id": "p3f2qa", "count": 1},
+            headers=PICNIC_HEADERS,
         )
         self.assertEqual(cart.type, "ORDER")
 
@@ -278,6 +280,7 @@ class TestClient(unittest.TestCase):
         self.session_mock().post.assert_called_with(
             self.expected_base_url + "/cart/add_product",
             json={"product_id": "gs4puhf3a", "count": 5},
+            headers=PICNIC_HEADERS,
         )
 
     def test_remove_product(self):
@@ -288,6 +291,7 @@ class TestClient(unittest.TestCase):
         self.session_mock().post.assert_called_with(
             self.expected_base_url + "/cart/remove_product",
             json={"product_id": "gs4puhf3a", "count": 5},
+            headers=PICNIC_HEADERS,
         )
 
     def test_clear_cart(self):
@@ -296,7 +300,9 @@ class TestClient(unittest.TestCase):
         )
         cart = self.client.clear_cart()
         self.session_mock().post.assert_called_with(
-            self.expected_base_url + "/cart/clear", json=None
+            self.expected_base_url + "/cart/clear",
+            json=None,
+            headers=PICNIC_HEADERS,
         )
         self.assertEqual(cart.type, "ORDER")
 


### PR DESCRIPTION
PicNic suddenly requires a client version for cart operations.

https://github.com/home-assistant/core/issues/178268